### PR TITLE
wrong variable name being passed from index to edit view

### DIFF
--- a/src/Templates/View/index.txt
+++ b/src/Templates/View/index.txt
@@ -10,7 +10,7 @@
 		<tr>
 
 {{content}}
-			<th><a href="{{ route('{{variables}}.edit', ${{variables}}->id) }}"> edit </a></th>
+			<th><a href="{{ route('{{variables}}.edit', ${{variable}}->id) }}"> edit </a></th>
 			
 		</tr>
 


### PR DESCRIPTION
$variable->id, not $variables->id (no '**s**') should be passed to the edit view from index view file.

found this when i got errors in the '/articles' route. Ive tried this on my local machine and the route works fine after this change.